### PR TITLE
Make sure full scan is run first

### DIFF
--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -36,6 +36,8 @@ module Guard
     # @raise [:task_has_failed] when stop has failed
     #
     def run_on_change(paths)
+      return run_all unless @tracker.checks
+
       puts "rescanning #{paths}, running all checks"
       report = ::Brakeman::rescan(@tracker, paths)
       print_failed(report)


### PR DESCRIPTION
This fixes this issue:

```
$ bundle exec guard init brakeman
Writing new Guardfile to /home/justin/work/brakeman/test/apps/rails3.1/Guardfile
brakeman guard added to Guardfile, feel free to edit it
[justin@localhost rails3.1]$ bundle exec guard start
Guard could not detect any of the supported notification libraries.
Guard is now watching at '/home/justin/work/brakeman/test/apps/rails3.1'
[Notice] Detected Rails 3 application
Processing configuration...
[Notice] Escaping HTML by default
Processing gems...
Processing initializers...
Processing libs...
Processing routes...        
Processing templates...     
Processing data flow in templates...
Processing models...        
Processing controllers...   
Processing data flow in controllers...
Indexing call sites...      
> rescanning ["app/views/users/show.html.erb"], running all checks

------ brakeman warnings --------
ERROR: Guard::Brakeman failed to achieve its <run_on_change>, exception was:
NoMethodError: undefined method `all_warnings' for nil:NilClass
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/brakeman-1.2.1/lib/brakeman/checks.rb:56:in `diff'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/brakeman-1.2.1/lib/brakeman/rescanner.rb:245:in `diff'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/brakeman-1.2.1/lib/brakeman/rescanner.rb:229:in `fixed_warnings'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-brakeman-0.1.4/lib/guard/brakeman.rb:55:in `print_changed'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-brakeman-0.1.4/lib/guard/brakeman.rb:41:in `run_on_change'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:369:in `block in run_supervised_task'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:367:in `catch'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:367:in `run_supervised_task'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:323:in `run_on_change_task'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:261:in `block (2 levels) in run_on_change'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:301:in `block (3 levels) in run_on_guards'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:300:in `each'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:300:in `block (2 levels) in run_on_guards'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:299:in `catch'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:299:in `block in run_on_guards'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:298:in `each'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:298:in `run_on_guards'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:260:in `block in run_on_change'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:277:in `block in run'
<internal:prelude>:10:in `synchronize'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:274:in `run'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard.rb:259:in `run_on_change'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard/listener.rb:89:in `block (2 levels) in start_reactor'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard/listener.rb:85:in `loop'
/home/justin/.rvm/gems/ruby-1.9.2-p290@rails3/gems/guard-1.0.0/lib/guard/listener.rb:85:in `block in start_reactor'

Guard::Brakeman has just been fired
```

Railroad jobs are scarce, so I don't want anyone getting fired...
