### PR TITLE
Use RescanReport#existing_warnings from 1.2.2

### DIFF
--- a/guard-brakeman.gemspec
+++ b/guard-brakeman.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = 'guard-brakeman'
 
   s.add_dependency 'guard',   '>= 0.2.2'
-  s.add_dependency 'brakeman', '>= 1.2'
+  s.add_dependency 'brakeman', '>= 1.2.2'
 
   s.add_development_dependency 'rspec',       '~> 2.6.0'
   s.add_development_dependency 'guard-rspec', '~> 0.3.1'

--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -66,13 +66,9 @@ module Guard
         puts
       end
 
-      existing = report.all_warnings.select do |w| 
-        not report.new_warnings.include? w
-      end
-
-      unless existing.empty?
-        puts "#{existing.length} previous warnings:"
-        puts existing.sort_by { |w| w.confidence }
+      unless report.existing_warnings.empty?
+        puts "#{report.existing_warnings.length} previous warnings:"
+        puts report.existing_warnings.sort_by { |w| w.confidence }
       end
     end
   end


### PR DESCRIPTION
This updates the Brakeman dependency to 1.2.2 so guard-brakeman can use RescanReport#existing_warnings.

And then it uses RescanReport#existing_warnings instead of computing them inside the guard.
