### PR TITLE
Make readme match default template and use newer ruby syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please read the [Guard usage documentation](https://github.com/guard/guard#readm
 Guard::Brakeman can be adapted to all kind of projects and comes with a default template that looks like this:
 
 ```ruby
-guard 'brakeman' do
+guard :brakeman, run_on_start: true do
   watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
   watch(%r{^config/.+\.rb$})
   watch(%r{^lib/.+\.rb$})

--- a/lib/guard/brakeman/templates/Guardfile
+++ b/lib/guard/brakeman/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'brakeman', :run_on_start => true do
+guard :brakeman, run_on_start: true do
   watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
   watch(%r{^config/.+\.rb$})
   watch(%r{^lib/.+\.rb$})


### PR DESCRIPTION
The default template did not match that in the README, and was using old syntax that I changed in my Guardfile to match my various other gems so thought I would put this up here.
